### PR TITLE
Fix bugs of src/hex

### DIFF
--- a/src/hex/hex.mbt
+++ b/src/hex/hex.mbt
@@ -8,7 +8,8 @@ let hex_table = "0123456789abcdef"
 let reverse_hex_table = b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xff\xff\xff\xff\xff\xff\xff\x0a\x0b\x0c\x0d\x0e\x0f\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\x0a\x0b\x0c\x0d\x0e\x0f"
 
 pub fn encode(input : Bytes) -> String {
-  let hex = StringBuilder::new(size_hint=4 * input.length())
+  //let hex = StringBuilder::new(size_hint=4 * input.length())
+  let hex = StringBuilder::new(size_hint=2 * input.length())
   for b in input {
     hex.write_char(hex_table[(b >> 4).to_int()])
     hex.write_char(hex_table[(b & 0x0f).to_int()])
@@ -25,11 +26,14 @@ pub fn decode(input : String) -> Bytes!HexDecodeError {
       raise InvalidHexCharError(c)
     }
   }
-  let bytes = Bytes::new(input.length() / 2)
+  //let bytes = Bytes::new(input.length() / 2)
+  let buf = @buffer.new()
   for i = 0; i < input.length(); i = i + 2 {
     let hi = reverse_hex_table[input[i].to_int()]
     let lo = reverse_hex_table[input[i + 1].to_int()]
-    bytes[i / 2] = (hi << 4) | lo
+    //bytes[i / 2] = ((hi << 4) | lo)
+    buf.write_byte(((hi << 4) | lo))
   }
-  bytes
+  //bytes
+  buf.to_bytes()
 }


### PR DESCRIPTION
Fixes #1 
fix: correct StringBuilder size_hint in hex encoding
- Change size_hint from 4*N to 2*N for exact pre-allocation

fix: correct decode function
- Change Bytes to @buffer.T to make it writable